### PR TITLE
Fix the radial axis ordering and the hover answer texts

### DIFF
--- a/src/draviz.py
+++ b/src/draviz.py
@@ -97,7 +97,7 @@ def read_data(questions_file: Path, answers_file: Path, company: str = None, lan
             2: "Delvis",
             3: "Ja"
         }
-    df["Answer_text"] = df["Answer"].apply(lambda x: dd.get(x, "Undefined"))
+    df["Answer_text"] = df["Answer"].apply(lambda x: dd.get(int(x), "Undefined"))
     return df, list(dd.values())
 
 

--- a/src/draviz.py
+++ b/src/draviz.py
@@ -50,7 +50,8 @@ def create_radar_plot(questions_file: Path, answers_file: Path, phases: List[str
                 tickmode="array",
                 tickvals=[0, 1, 2, 3],
                 ticktext=answers_list,
-                range=[0, 3]
+                range=[0, 3],
+                categoryorder="category ascending"
             ),
             angularaxis=dict(
                 direction="clockwise"


### PR DESCRIPTION
Hi, Fredrik! Thank you for creating and open sourcing draviz!

Today I was using it, and noticed two minimal bugs, which is why I am opening this PR. 

The PR goals are:
- to guarantee that answer texts are always displayed in correct order in the radial axis;
- to fix the problem of getting undefined answer text when hovering over the answers in the chart - this happens when pandas sets the Answer column type as string, which might happen in case the user writes things such as "-" for questions that do not apply?

I would be glad to hear what you think. Cheers!